### PR TITLE
refactor: replace papermill with nbclient for notebook execution

### DIFF
--- a/.github/workflows/notebook_runner.yml
+++ b/.github/workflows/notebook_runner.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Verify Token Access
         run: |
           RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${{ secrets.BLUEPRINT_GITHUB_TEST_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.BLUEPRINT_GITHUB_TEST_TOKEN_ON_GH }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/NVIDIA-AI-Blueprints/blueprint-github-test")
 
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "NVIDIA-AI-Blueprints/blueprint-github-test"
-          token: ${{ secrets.BLUEPRINT_GITHUB_TEST_TOKEN }}
+          token: ${{ secrets.BLUEPRINT_GITHUB_TEST_TOKEN_ON_GH }}
           path: blueprint-github-test
           fetch-depth: 1
 
@@ -307,7 +307,8 @@ jobs:
               fi
           done
 
-          pip install jupyter papermill pytest-html pytest-cov
+          pip install ipykernel nbclient nbformat jupyter nbconvert pytest-html pytest-cov
+          python3 -m ipykernel install --user --name python3 --display-name "Python 3"
 
           echo '=== Verifying installations ==='
           pip list
@@ -316,78 +317,107 @@ jobs:
           jupyter kernelspec list
           EOF
 
-      - name: Run Jupyter Notebook
+      - name: Download notebook_runner_nbclient.py
+        run: |
+          curl -H "Authorization: token ${{ secrets.BLUEPRINT_GITHUB_TEST_TOKEN_ON_GH }}" \
+            -o notebook_runner_nbclient.py \
+            https://raw.githubusercontent.com/NVIDIA-AI-Blueprints/blueprint-github-test/main/utils/notebook_runner/notebook_runner_nbclient.py
+          chmod +x notebook_runner_nbclient.py
+          
+          # Copy to container
+          docker compose -f "$DOCKER_COMPOSE_FILE" cp notebook_runner_nbclient.py backend:/notebooks/
+
+      - name: Run Jupyter Notebook with nbclient
         id: run-jupyter-notebook
         timeout-minutes: 30
         run: |
           # NOTE: matrix expression won't be parsed in EOF
           NOTEBOOK_RELATIVED_DIR="${{ env.NOTEBOOK_RELATIVED_DIR }}"
           NOTEBOOK_FILENAME="${{ steps.set_global_vars.outputs.notebook_filename }}"
+          NOTEBOOK_BASENAME="${{ steps.set_global_vars.outputs.notebook_basename }}"
           OUTPUT_NOTEBOOK="${{ env.OUTPUT_NOTEBOOK }}"
+          OUTPUT_NOTEBOOK_HTML="${{ env.OUTPUT_NOTEBOOK_HTML }}"
           DOCKER_WRITEABLE_DIR="${{ env.DOCKER_WRITEABLE_DIR }}"
 
-          echo "=============== Executing notebook ====================="
+          echo "=============== Executing notebook with nbclient ====================="
 
           docker compose -f "$DOCKER_COMPOSE_FILE" exec -u root backend bash <<EOF
           set -euxo pipefail
           export PYTHONUNBUFFERED=1
 
-          papermill "${NOTEBOOK_RELATIVED_DIR}/${NOTEBOOK_FILENAME}" "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK}" \
-            --log-output \
-            --log-level DEBUG \
-            --progress-bar \
-            --report-mode \
-            --kernel python3 2>&1 | tee "${DOCKER_WRITEABLE_DIR}/papermill.log"
+          cd /notebooks
 
-          echo "===============Check file====================="
-          if [ -s "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK" ]; then
-              echo "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK exists and has contents"
+          python3 notebook_runner_nbclient.py \
+            -f "${NOTEBOOK_RELATIVED_DIR}/${NOTEBOOK_FILENAME}" \
+            --output-dir "${DOCKER_WRITEABLE_DIR}" \
+            --timeout 3600 \
+            --skip-deps-check \
+            --kernel python3 2>&1 | tee "${DOCKER_WRITEABLE_DIR}/nbclient.log"
+
+          # The script generates files with names based on input notebook basename
+          # Move files to expected names for compatibility
+          EXECUTED_NOTEBOOK="${DOCKER_WRITEABLE_DIR}/${NOTEBOOK_BASENAME}.executed.ipynb"
+          HTML_FILE="${DOCKER_WRITEABLE_DIR}/${NOTEBOOK_BASENAME}.html"
+
+          echo "===============Check generated files====================="
+          ls -la "${DOCKER_WRITEABLE_DIR}/" | grep -E "\.(html|ipynb)$" || echo "No HTML/notebook files found"
+
+          # Rename executed notebook to expected name
+          if [ -f "\$EXECUTED_NOTEBOOK" ]; then
+            cp "\$EXECUTED_NOTEBOOK" "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK}"
+            echo "Copied executed notebook to ${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK}"
           else
-              echo "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK does NOT exist or has NO contents"
+            echo "ERROR: Executed notebook not found at \$EXECUTED_NOTEBOOK"
+            exit 1
           fi
-          echo "===============Check file====================="
 
-          echo '=== Papermill logs ==='
-          cat "$DOCKER_WRITEABLE_DIR/papermill.log"
+          # Rename HTML file to expected name
+          if [ -f "\$HTML_FILE" ]; then
+            cp "\$HTML_FILE" "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML}"
+            echo "Copied HTML file to ${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML}"
+          else
+            echo "ERROR: HTML file not found at \$HTML_FILE"
+            exit 1
+          fi
+
+          echo "===============Verify output files====================="
+          if [ -s "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK}" ]; then
+              echo "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK} exists and has contents"
+          else
+              echo "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK} does NOT exist or has NO contents"
+              exit 1
+          fi
+
+          if [ -s "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML}" ]; then
+              echo "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML} exists and has contents"
+          else
+              echo "${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML} does NOT exist or has NO contents"
+              exit 1
+          fi
+
+          echo '=== nbclient logs ==='
+          cat "${DOCKER_WRITEABLE_DIR}/nbclient.log"
           EOF
 
           echo "=============== Executing notebook --- Done ====================="
 
-      - name: Convert result to html format
+      - name: Set notebook execution result
         id: generate-notebook-html
         if: steps.run-jupyter-notebook.outcome == 'success'
         run: |
-          echo "Run jupyter notebook succeeded, running Convert result to HTML format"
-          OUTPUT_NOTEBOOK="${{ env.OUTPUT_NOTEBOOK }}"
+          echo "Notebook execution and HTML conversion completed successfully"
           OUTPUT_NOTEBOOK_HTML="${{ env.OUTPUT_NOTEBOOK_HTML }}"
           DOCKER_WRITEABLE_DIR="${{ env.DOCKER_WRITEABLE_DIR }}"
 
-          docker compose -f "$DOCKER_COMPOSE_FILE" exec -u root backend bash <<EOF
-          cd "$DOCKER_WRITEABLE_DIR"
-          echo "Converting notebook: $OUTPUT_NOTEBOOK to HTML"
-          echo "Working directory: \$(pwd)"
-          ls -la "$OUTPUT_NOTEBOOK" || echo "Source notebook not found"
-          
-          jupyter nbconvert --to html "$OUTPUT_NOTEBOOK" \
-            --output "\$(basename "$OUTPUT_NOTEBOOK_HTML" .html)" \
-            > "jupyter_nbconvert.log" 2>&1
-          
-          echo "Conversion completed, checking results..."
-          ls -la *.html || echo "No HTML files found"
-          EOF
-
-          docker compose -f "$DOCKER_COMPOSE_FILE" exec -T -u root backend bash -c '
-            echo "===jupyter_nbconvert logs==="
-            cat "$DOCKER_WRITEABLE_DIR/jupyter_nbconvert.log"
-
-            echo "===============Check file====================="
-            if [ -s "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK_HTML" ]; then
-                echo "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK_HTML exists and has contents"
+          docker compose -f "$DOCKER_COMPOSE_FILE" exec -T -u root backend bash -c "
+            echo '===============Check HTML file====================='
+            if [ -s \"${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML}\" ]; then
+                echo \"${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML} exists and has contents\"
             else
-                echo "$DOCKER_WRITEABLE_DIR/$OUTPUT_NOTEBOOK_HTML does NOT exist or has NO contents"
+                echo \"${DOCKER_WRITEABLE_DIR}/${OUTPUT_NOTEBOOK_HTML} does NOT exist or has NO contents\"
             fi
-            echo "===============Check file====================="
-          '
+            echo '===============Check file====================='
+          "
 
       - name: Install Poetry/Dependencies and execute pytest
         id: run-pytest


### PR DESCRIPTION
- Update token secret name to BLUEPRINT_GITHUB_TEST_TOKEN_ON_GH
- Switch from papermill to nbclient for better GPU context handling
- Add notebook_runner_nbclient.py download step from test repo
- Install nbclient, nbformat instead of papermill
- Register Jupyter kernel explicitly
- nbclient script handles both notebook execution and HTML conversion